### PR TITLE
fix/only action should return promise

### DIFF
--- a/examples/chat/src/actions/MessageActions.js
+++ b/examples/chat/src/actions/MessageActions.js
@@ -11,16 +11,23 @@ import ChatWebAPIUtils from "../utils/ChatWebAPIUtils";
 const MessageActions = Goflux.defineActions("MessageActions", function (context) {
   return {
     createMessage (text, currentThreadID) {
-      return context.dispatch("CREATE_MESSAGE", {/* payload */
+      context.dispatch("CREATE_MESSAGE", {/* payload */
         text,
         currentThreadID,
-      }).then((dispatchedResult) => {
-        // ignore dispatchResult for now.
+      });
+
+      return Promise.resolve(true).then(() => {
+        /*
+         * Only after current tick, you're allowed to execute another action
+         */
         const message = ChatMessageUtils.getCreatedMessageData(text, currentThreadID);
-        ChatWebAPIUtils.createMessage(message).then((createdMessage) => {
+        const promise = ChatWebAPIUtils.createMessage(message).then((createdMessage) => {
           return context.gofluxAction("ServerActions").receiveCreatedMessage(createdMessage);
         });
-        return dispatchResult;
+        /*
+         * Ignore promise here since we don't care.
+         */
+        return true;
       });
     },
   };

--- a/examples/chat/src/actions/ServerActions.js
+++ b/examples/chat/src/actions/ServerActions.js
@@ -8,15 +8,17 @@ import Goflux from "goflux";
 const ServerActions = Goflux.defineActions("ServerActions", function (context) {
   return {
     receiveAll (rawMessages) {
-      return context.dispatch("RECEIVE_RAW_MESSAGES", {/* payload */
+      context.dispatch("RECEIVE_RAW_MESSAGES", {/* payload */
         rawMessages,
       });
+      return Promise.resolve(true);
     },
 
     receiveCreatedMessage (createdMessage) {
-      return context.dispatch("RECEIVE_RAW_CREATED_MESSAGE", {/* payload */
+      context.dispatch("RECEIVE_RAW_CREATED_MESSAGE", {/* payload */
         rawMessage: createdMessage,
       });
+      return Promise.resolve(true);
     },
   };
 });

--- a/examples/chat/src/actions/ThreadActions.js
+++ b/examples/chat/src/actions/ThreadActions.js
@@ -8,9 +8,10 @@ import Goflux from "goflux";
 const ThreadActions = Goflux.defineActions("ThreadActions", function (context) {
   return {
     clickThread (threadID) {
-      return context.dispatch("CLICK_THREAD", {/* payload */
+      context.dispatch("CLICK_THREAD", {/* payload */
         threadID,
       });
+      return Promise.resolve(true);
     },
   };
 });

--- a/examples/chat/src/stores/MessageStore.js
+++ b/examples/chat/src/stores/MessageStore.js
@@ -88,13 +88,12 @@ function (context) {
     },
 
     _click_thread_ () {
-      return context.waitFor(["ThreadStore"]).then(([threadStoreHandleResult]) => {
-        this._mark_all_in_thread_read_(
-          context.getStore("ThreadStore").getCurrentID()
-        );
-        this._emit_change_();
-        return true;
-      });
+      context.waitFor(["ThreadStore"]);
+
+      this._mark_all_in_thread_read_(
+        context.getStore("ThreadStore").getCurrentID()
+      );
+      this._emit_change_();
     },
 
     _create_message_ (payload) {
@@ -104,18 +103,17 @@ function (context) {
       );
       _messages[message.id] = message;
       this._emit_change_();
-      return true;
     },
 
     _receive_raw_messages_ ({rawMessages}) {
       this._add_messages_(rawMessages);
-      return context.waitFor(["ThreadStore"]).then(([threadStoreHandleResult]) => {
-        this._mark_all_in_thread_read_(
-          context.getStore("ThreadStore").getCurrentID()
-        );
-        this._emit_change_();
-        return true;
-      });
+
+      context.waitFor(["ThreadStore"]);
+
+      this._mark_all_in_thread_read_(
+        context.getStore("ThreadStore").getCurrentID()
+      );
+      this._emit_change_();
     },
   };
 });

--- a/examples/chat/src/stores/ThreadStore.js
+++ b/examples/chat/src/stores/ThreadStore.js
@@ -101,13 +101,11 @@ class ThreadStore extends EventEmitter {
     this._currentID = payload.threadID;
     this._threads[this._currentID].lastMessage.isRead = true;
     this._emit_change_();
-    return true;
   },
 
   _receive_raw_messages_ ({rawMessages}) {
     this._init_(rawMessages);
     this._emit_change_();
-    return true;
   },
 });
 

--- a/examples/chat/src/stores/UnreadThreadStore.js
+++ b/examples/chat/src/stores/UnreadThreadStore.js
@@ -48,17 +48,15 @@ class UnreadThreadStore extends EventEmitter {
   },
 
   _click_thread_ () {
-    return this._context.waitFor(["ThreadStore", "MessageStore"]).then(() => {
-      this._emit_change_();
-      return true;
-    });
+    this._context.waitFor(["ThreadStore", "MessageStore"]);
+
+    this._emit_change_();
   },
 
   _receive_raw_messages_ () {
-    return this._context.waitFor(["ThreadStore", "MessageStore"]).then(() => {
-      this._emit_change_();
-      return true;
-    });
+    this._context.waitFor(["ThreadStore", "MessageStore"]);
+
+    this._emit_change_();
   },
 });
 


### PR DESCRIPTION
# Why

Inspired by [flux](https://github.com/facebook/flux).

## Flux diagram
Look at the [flux diagram](https://raw.githubusercontent.com/facebook/flux/master/docs/img/flux-diagram-white-background.png) carefully.
![flux diagram](https://raw.githubusercontent.com/facebook/flux/master/docs/img/flux-diagram-white-background.png)

You'll see, only the `ActionCreators` are allowed to issue an [fetch](https://github.com/github/fetch) request. That means,
* Actions are asynchronous. i.e, they should return a promise
* Dispatch event from ActionCreators -> Dispatcher -> Stores are synchronous.
* When response is back from server, issue another Action (we call it `ServerAction`) to add the data into this flow.

## Result

* Remove return promise of `dispatch` method
* Remove return promise of `waitFor` method
* Remove return promise of instances methods of `Store`s.
